### PR TITLE
Add composer support to install pimcore-plugin DynamicDropdown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,3 +44,4 @@ Patch kindly provided by Thomas Akkermans (http://www.pimcore.org/board/memberli
   and like the href-tag the grid can't be sorted by this column.
   Thanks to quintworld for reporting.
 - Recursive searching in the specified folder, configurable in the setup.
+- Add composer support

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "authors":[
         {
             "name":"Thomas KEIL",
-            "homepage":"https://github.com/ThomasKeil",
+            "homepage":"https://github.com/ThomasKeil"
         }
     ],
     "require":{

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name":"thomas-keil/dynamic-dropdown",
+    "type":"pimcore-plugin",
+    "description":"Populate Comboboxes with Object content of a selected folder",
+    "keywords":["pimcore", "plugin", "Dynamic Dropbox Module"],
+    "homepage":"https://github.com/ThomasKeil/pimcore-plugin-DynamicDropdown",
+    "authors":[
+        {
+            "name":"Thomas KEIL",
+            "homepage":"https://github.com/ThomasKeil",
+        }
+    ],
+    "require":{
+        "composer/installers": "1.0.15"
+    },
+    "minimum-stability":"dev",
+    "autoload":{
+        "psr-0":{
+            "": ""
+        }
+    }
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,7 +7,7 @@
         <!-- Plugin Server Host-->
         <pluginServer></pluginServer>
         <!-- Version and Revision are updated by createRevision Script !-->
-        <pluginVersion>0.0.8</pluginVersion>
+        <pluginVersion>0.0.9</pluginVersion>
         <pluginRevision>1</pluginRevision>
         <pluginBuildTimestamp>1336112744</pluginBuildTimestamp>
         <!-- <pluginIframeSrc>/plugin/DynamicDropdown/admin/settings</pluginIframeSrc> -->


### PR DESCRIPTION
Hi !

This pull request to add composer support.
I add composer.json which allow you to install your plugin in a Pimcore project with composer.

You just need to add a
- require "thomas-keil/dynamic-dropdown", "dev-master"
  or
- require "thomas-keil/dynamic-dropdown", "0.0.9"

I made a tag release v0.0.9 on my last commit to allow the last require.

Cordially,
Benjamin MARROT
